### PR TITLE
Add energy bar fail animation.

### DIFF
--- a/BailOutMode/BailOutController.cs
+++ b/BailOutMode/BailOutController.cs
@@ -28,6 +28,7 @@ namespace BailOutMode
         public bool isHiding = false;
         public int numFails = 0;
         private LevelFailedTextEffect LevelFailedEffect;
+        private PlayableDirector LevelFailedEnergyBarAnimation;
 
         public bool IsEnabled
         {
@@ -119,6 +120,7 @@ namespace BailOutMode
             LevelFailedEffect = GameObject.FindObjectOfType<LevelFailedTextEffect>();
             if (LevelFailedEffect == null)
                 Logger.log?.Warn("Couldn't find LevelFailedTextEffect");
+            LevelFailedEnergyBarAnimation = (PlayableDirector)AccessTools.Field(typeof(GameEnergyUIPanel), "_playableDirector").GetValue(GameObject.FindObjectOfType<GameEnergyUIPanel>());
         }
 
         private void OnDestroy()
@@ -137,23 +139,33 @@ namespace BailOutMode
             //Logger.Trace("BailOutController ShowLevelFailed()");
             //BS_Utils.Gameplay.ScoreSubmission.DisableSubmission(Plugin.PluginName); Don't need this here
             UpdateFailText($"Bailed Out {numFails} time{(numFails != 1 ? "s" : "")}");
-            if (!isHiding && Configuration.instance.ShowFailEffect && LevelFailedEffect != null)
+            try
             {
-                try
-                {
-                    if (!Configuration.instance.RepeatFailEffect && numFails > 1)
-                        return; // Don't want to repeatedly show fail effect, stop here.
+                if (!Configuration.instance.RepeatFailEffect && numFails > 1)
+                    return; // Don't want to repeatedly show fail effect, stop here.
 
-                    //Logger.Debug("Showing fail effect");
-                    GameEnergyUIPanel gameEnergyUIPanel = GameObject.FindObjectsOfType<GameEnergyUIPanel>().FirstOrDefault();
-                    PlayableDirector failDirector = (PlayableDirector)AccessTools.Field(typeof(GameEnergyUIPanel), "_playableDirector").GetValue(gameEnergyUIPanel);
-                    failDirector.Play();
-                }
-                catch (Exception ex)
+                //Logger.Debug("Showing fail effects");
+                if (!isHiding && Configuration.instance.ShowFailEffect && LevelFailedEffect != null)
                 {
-                    Logger.log.Error($"Exception trying to show the fail Effect: {ex.Message}");
-                    Logger.log.Debug(ex);
+                    LevelFailedEffect.ShowEffect();
+                    if (Configuration.instance.FailEffectDuration > 0)
+                        StartCoroutine(hideLevelFailed());
+                    else
+                        isHiding = true; // Fail text never hides, so don't try to keep showing it
                 }
+
+                if (Configuration.instance.ShowFailAnimation && LevelFailedEnergyBarAnimation != null)
+                {
+                    // Cancel any in-progress fail animation before playing a new animation, to prevent missing an animation when failing multiple times in quick succession.
+                    LevelFailedEnergyBarAnimation.Stop();
+                    LevelFailedEnergyBarAnimation.Play();
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Logger.log.Error($"Exception trying to show the fail Effects: {ex.Message}");
+                Logger.log.Debug(ex);
             }
         }
         private int lastFailDuration = Configuration.instance.FailEffectDuration;

--- a/BailOutMode/BailOutController.cs
+++ b/BailOutMode/BailOutController.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using UnityEngine.Playables;
+using HarmonyLib;
 using TMPro;
 using Zenject;
 
@@ -143,11 +145,9 @@ namespace BailOutMode
                         return; // Don't want to repeatedly show fail effect, stop here.
 
                     //Logger.Debug("Showing fail effect");
-                    LevelFailedEffect.ShowEffect();
-                    if (Configuration.instance.FailEffectDuration > 0)
-                        StartCoroutine(hideLevelFailed());
-                    else
-                        isHiding = true; // Fail text never hides, so don't try to keep showing it
+                    GameEnergyUIPanel gameEnergyUIPanel = GameObject.FindObjectsOfType<GameEnergyUIPanel>().FirstOrDefault();
+                    PlayableDirector failDirector = (PlayableDirector)AccessTools.Field(typeof(GameEnergyUIPanel), "_playableDirector").GetValue(gameEnergyUIPanel);
+                    failDirector.Play();
                 }
                 catch (Exception ex)
                 {

--- a/BailOutMode/BailOutMode.csproj
+++ b/BailOutMode/BailOutMode.csproj
@@ -99,6 +99,10 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.DirectorModule">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.DirectorModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>

--- a/BailOutMode/BailOutMode.csproj
+++ b/BailOutMode/BailOutMode.csproj
@@ -125,7 +125,7 @@
   <ItemGroup>
     <Compile Include="BailOutInstaller.cs" />
     <Compile Include="Configuration.cs" />
-    <Compile Include="Harmony_Patches\GameEnergyCounterAddEnergy.cs" />
+    <Compile Include="Harmony_Patches\GameEnergyCounterProcessEnergyChange.cs" />
     <Compile Include="BailOutController.cs" />
     <Compile Include="Harmony_Patches\MultiplayerHandleSongDidFinish.cs" />
     <Compile Include="Harmony_Patches\HandleSongDidFinish.cs" />

--- a/BailOutMode/Configuration.cs
+++ b/BailOutMode/Configuration.cs
@@ -9,6 +9,7 @@ namespace BailOutMode
     {
         public const bool IsEnabled = true;
         public const bool EnableGameplayTab = true;
+        public const bool ShowFailAnimation = true;
         public const bool ShowFailEffect = true;
         public const bool RepeatFailEffect = false;
         public const bool DynamicSettings = false;
@@ -52,6 +53,10 @@ namespace BailOutMode
                 Plugin.instance.SetGameplaySetupTab(value);
             }
         }
+
+        [UIValue("ShowFailAnimation")]
+        public virtual bool ShowFailAnimation { get; set; } = DefaultSettings.ShowFailAnimation;
+
         [UIValue("ShowFailEffect")]
         public virtual bool ShowFailEffect { get; set; } = DefaultSettings.ShowFailEffect;
 

--- a/BailOutMode/Harmony_Patches/GameEnergyCounterProcessEnergyChange.cs
+++ b/BailOutMode/Harmony_Patches/GameEnergyCounterProcessEnergyChange.cs
@@ -10,22 +10,22 @@ using BS_Utils;
 
 namespace BailOutMode.Harmony_Patches
 {
-    [HarmonyPatch(typeof(GameEnergyCounter), nameof(GameEnergyCounter.AddEnergy),
+    [HarmonyPatch(typeof(GameEnergyCounter), nameof(GameEnergyCounter.ProcessEnergyChange),
         new Type[] {
         typeof(float)})]
-    class GameEnergyCounterAddEnergy
+    class GameEnergyCounterProcessEnergyChange
     {
-        static bool Prefix(GameEnergyCounter __instance, ref float value)
+        static bool Prefix(GameEnergyCounter __instance, ref float energyChange)
         {
-            //Logger.Trace("In GameEnergyCounter.AddEnergy()");
+            //Logger.Trace("In GameEnergyCounter.ProcessEnergyChange()");
             if (BailOutController.instance == null)
                 return true;
-            if (value < 0f && BailOutController.instance.IsEnabled)
+            if (energyChange < 0f && BailOutController.instance.IsEnabled)
             {
-                //Logger.Trace("Negative energy change detected: {0}", value);
-                if (__instance.energy + value <= 1E-05f)
+                //Logger.Trace("Negative energy change detected: {0}", energyChange);
+                if (__instance.energy + energyChange <= 1E-05f)
                 {
-                    // Logger.log?.Debug($"Fail detected. Current Energy: {__instance.energy}, Energy Change: {value}");
+                    // Logger.log?.Debug($"Fail detected. Current Energy: {__instance.energy}, Energy Change: {energyChange}");
                     if (BS_Utils.Gameplay.ScoreSubmission.Disabled == false
                         || BailOutController.instance.numFails == 0)
                     {
@@ -37,9 +37,9 @@ namespace BailOutMode.Harmony_Patches
                     if (!BS_Utils.Gameplay.ScoreSubmission.Disabled)
                         Logger.log.Error($"Told BS_Utils to disable submission, but it seems to still be enabled.");
                     BailOutController.instance.numFails++;
-                    // Logger.log?.Debug($"{__instance.energy} + {value} puts us <= 0");
-                    value = (Configuration.instance.EnergyResetAmount / 100f) - __instance.energy;
-                    // Logger.log?.Debug($"Changing value to {value} to raise energy to {Configuration.instance.EnergyResetAmount}");
+                    // Logger.log?.Debug($"{__instance.energy} + {energyChange} puts us <= 0");
+                    energyChange = (Configuration.instance.EnergyResetAmount / 100f) - __instance.energy;
+                    // Logger.log?.Debug($"Changing energyChange to {energyChange} to raise energy to {Configuration.instance.EnergyResetAmount}");
                     BailOutController.instance.OnLevelFailed();
                 }
             }

--- a/BailOutMode/UI/Settings.bsml
+++ b/BailOutMode/UI/Settings.bsml
@@ -1,9 +1,10 @@
 ﻿<settings-container xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
   <bool-setting text='Enabled' value='IsEnabled' hover-hint='Enable BailOutMode'/>
   <bool-setting text='Enable Gameplay Tab' value='EnableGameplayTab' hover-hint='Enable gameplay setup tab'/>
-  <bool-setting text='Show Fail Effect' value='ShowFailEffect' hover-hint='Show the Level Failed effect when bailed out'/>
-  <bool-setting text='Repeat Fail Effect' value='RepeatFailEffect' hover-hint='Show the Level Failed effect every time a bail out happens'/>
-  <increment-setting text='Fail Effect Duration' value='FailEffectDuration' hover-hint='How long the Level Failed effect is displayed' integer-only='true' increment='1' min='1' max='15'/>
+  <bool-setting text='Show Fail Energy Bar Animation' value='ShowFailAnimation' hover-hint='Show the energy bar fail animation when bailed out'/>
+  <bool-setting text='Show Fail Text Effect' value='ShowFailEffect' hover-hint='Show the Level Failed text effect when bailed out'/>
+  <bool-setting text='Repeat Fail Effects' value='RepeatFailEffect' hover-hint='Show the Level Failed effects every time a bail out happens'/>
+  <increment-setting text='Fail Text Effect Duration' value='FailEffectDuration' hover-hint='How long the Level Failed text effect is displayed' integer-only='true' increment='1' min='1' max='15'/>
   <slider-setting text='Energy Reset Amount' value='EnergyResetAmount' hover-hint='How much energy is gained back after a bail out' min='30' max='100' integer-only='true'/>
   <string-setting text='Counter Text Position' value='CounterTextPosition' hover-hint='Where the Bail Out counter text is shown'/>
   <increment-setting text='Counter Text Size' value='CounterTextSize' hover-hint='How large the text of the Bail Out counter is' min='1'/>

--- a/BailOutMode/manifest.json
+++ b/BailOutMode/manifest.json
@@ -5,7 +5,7 @@
   "id": "bailoutmode",
   "description": "Allows you to continue playing songs without posting a score if you fail, but allows you to post scores if you don't.",
   "version": "1.7.3",
-  "gameVersion": "1.13.0",
+  "gameVersion": "1.13.2",
   "dependsOn": {
     "BSIPA": "^4.1.3",
     "BS Utils": "^1.6.2",


### PR DESCRIPTION
- The energy bar fail animation is controlled by its own config setting independently from the Level Failed text effect.
- The existing config names were not changed, to maintain backwards-compatibility with existing config files. (At the expense of some variable names becoming slightly out-of-date.)
- Updated the display text and hover text of the settings to be consistent with having two different fail effects.

This PR contains some incidental code for updating to Beat Saber version 1.13.2, but that should clear up once https://github.com/Zingabopp/BailOutMode/pull/12 is resolved.