### PR TITLE
Update for Beat Saber 1.19.0

### DIFF
--- a/BailOutMode/BailOutController.cs
+++ b/BailOutMode/BailOutController.cs
@@ -237,7 +237,7 @@ namespace BailOutMode
                         Logger.log?.Debug($"All other players failed, triggering level failed.");
                         if (MultiGameplayManager != null)
                         {
-                            MultiGameplayManager.HandleGameEnergyDidReach0();
+                            MultiGameplayManager.GetType().GetMethod("HandleGameEnergyDidReach0").Invoke(MultiGameplayManager, new object[] { });
                         }
                         else
                             Logger.log?.Warn($"Tried to fail level, but ILevelEndActions isn't a StandardLevelGameplayManager.");

--- a/BailOutMode/BailOutInstaller.cs
+++ b/BailOutMode/BailOutInstaller.cs
@@ -14,7 +14,7 @@ namespace BailOutMode
         public override void InstallBindings()
         {
             Logger.log?.Info("Injecting Dependencies");
-            Container.Bind<BailOutController>().FromNewComponentOnNewGameObject("BailOutController").AsSingle().NonLazy();
+            Container.Bind<BailOutController>().FromNewComponentOnNewGameObject().AsSingle().NonLazy();
         }
     }
 }

--- a/BailOutMode/BailOutMode.csproj
+++ b/BailOutMode/BailOutMode.csproj
@@ -38,9 +38,9 @@
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="BGNet">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNet.dll</HintPath>
+    <Reference Include="BGNetCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNetCore.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BSML">
@@ -52,6 +52,11 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="DataModels, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="GameplayCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>

--- a/BailOutMode/Harmony_Patches/GameEnergyCounterProcessEnergyChange.cs
+++ b/BailOutMode/Harmony_Patches/GameEnergyCounterProcessEnergyChange.cs
@@ -10,7 +10,7 @@ using BS_Utils;
 
 namespace BailOutMode.Harmony_Patches
 {
-    [HarmonyPatch(typeof(GameEnergyCounter), nameof(GameEnergyCounter.ProcessEnergyChange),
+    [HarmonyPatch(typeof(GameEnergyCounter), "ProcessEnergyChange",
         new Type[] {
         typeof(float)})]
     class GameEnergyCounterProcessEnergyChange

--- a/BailOutMode/Harmony_Patches/HandleSongDidFinish.cs
+++ b/BailOutMode/Harmony_Patches/HandleSongDidFinish.cs
@@ -10,7 +10,7 @@ using BS_Utils;
 
 namespace BailOutMode.Harmony_Patches
 {
-    [HarmonyPatch(typeof(StandardLevelGameplayManager), nameof(StandardLevelGameplayManager.HandleSongDidFinish),
+    [HarmonyPatch(typeof(StandardLevelGameplayManager), "HandleSongDidFinish",
     new Type[] { })]
     internal class StandardLevelGameplayManagerHandleSongDidFinish
     {
@@ -24,7 +24,7 @@ namespace BailOutMode.Harmony_Patches
                 if (BailOutController.instance.numFails > 0)
                 {
                     Logger.log.Debug("Fail detected in BailOutController, forcing level failed");
-                    __instance.HandleGameEnergyDidReach0();
+                    __instance.GetType().GetMethod("HandleGameEnergyDidReach0").Invoke(__instance, new object[] {});
                     return false;
                 }
             }

--- a/BailOutMode/Harmony_Patches/MultiplayerHandleSongDidFinish.cs
+++ b/BailOutMode/Harmony_Patches/MultiplayerHandleSongDidFinish.cs
@@ -10,7 +10,7 @@ using BS_Utils;
 
 namespace BailOutMode.Harmony_Patches
 {
-    [HarmonyPatch(typeof(MultiplayerLocalActivePlayerGameplayManager), nameof(MultiplayerLocalActivePlayerGameplayManager.HandleSongDidFinish),
+    [HarmonyPatch(typeof(MultiplayerLocalActivePlayerGameplayManager), "HandleSongDidFinish",
     new Type[] { })]
     internal class MultiplayerLocalActivePlayerGameplayManagerHandleSongDidFinish
     {
@@ -24,7 +24,7 @@ namespace BailOutMode.Harmony_Patches
                 if (BailOutController.instance.numFails > 0)
                 {
                     Logger.log.Debug("Fail detected in BailOutController, forcing level failed");
-                    __instance.HandleGameEnergyDidReach0();
+                    __instance.GetType().GetMethod("HandleGameEnergyDidReach0").Invoke(__instance, new object[] { });
                     return false;
                 }
             }

--- a/BailOutMode/Harmony_Patches/MultiplayerLocalActiveClient_ScoreControllerHandleScoreDidChange.cs
+++ b/BailOutMode/Harmony_Patches/MultiplayerLocalActiveClient_ScoreControllerHandleScoreDidChange.cs
@@ -12,7 +12,7 @@ namespace BailOutMode.Harmony_Patches
     /// <summary>
     /// This patches ClassToPatch.MethodToPatch(Parameter1Type arg1, Parameter2Type arg2)
     /// </summary>
-    [HarmonyPatch(typeof(MultiplayerLocalActiveClient), nameof(MultiplayerLocalActiveClient.ScoreControllerHandleScoreDidChange),
+    [HarmonyPatch(typeof(MultiplayerLocalActiveClient), "HandleScoreDidChange",
         new Type[] { // List the Types of the method's parameters.
         typeof(int),
         typeof(int)})]
@@ -23,12 +23,12 @@ namespace BailOutMode.Harmony_Patches
             Plugin.LevelStarted += OnLevelStarted;
         }
 
-        public static int lastRawScore { get; private set; } = -1;
+        public static int lastMultipliedScore { get; private set; } = -1;
         public static int lastModifiedScore { get; private set; } = -1;
 
         public static void ResetLastScores()
         {
-            lastRawScore = -1;
+            lastMultipliedScore = -1;
             lastModifiedScore = -1;
         }
 
@@ -37,11 +37,11 @@ namespace BailOutMode.Harmony_Patches
             ResetLastScores();
         }
 
-        static bool Prefix(ref int rawScore, ref int modifiedScore)
+        static bool Prefix(ref int multipliedScore, ref int modifiedScore)
         {
             if (BailOutController.instance.numFails > 0)
                 return false;
-            lastRawScore = rawScore;
+            lastMultipliedScore = multipliedScore;
             lastModifiedScore = modifiedScore;
             return true;
         }

--- a/BailOutMode/Harmony_Patches/ScoreController_Patches.cs
+++ b/BailOutMode/Harmony_Patches/ScoreController_Patches.cs
@@ -9,33 +9,33 @@ using HarmonyLib;
 /// </summary>
 namespace BailOutMode.Harmony_Patches
 {
-    [HarmonyPatch(typeof(ScoreController), nameof(ScoreController.prevFrameRawScore), MethodType.Getter)]
+    [HarmonyPatch(typeof(ScoreController), nameof(ScoreController.multipliedScore), MethodType.Getter)]
     public class ScoreController_prevFrameRawScore
     {
-        static bool Prefix(ref int ____prevFrameRawScore, ref int __result)
+        static bool Prefix(ref int ____multipliedScore, ref int __result)
         {
-            int lastRawScore = MultiplayerLocalActiveClient_ScoreControllerHandleScoreDidChange.lastRawScore;
-            if (BailOutController.instance.numFails > 0 && lastRawScore >= 0)
+            int lastMultipliedScore = MultiplayerLocalActiveClient_ScoreControllerHandleScoreDidChange.lastMultipliedScore;
+            if (BailOutController.instance.numFails > 0 && lastMultipliedScore >= 0)
             {
 #if DEBUG
-                Logger.log?.Debug($"Multiplayer Bailout detected. Overriding raw score '{____prevFrameRawScore}' with '{lastRawScore}'");
+                Logger.log?.Debug($"Multiplayer Bailout detected. Overriding multiplied score '{____multipliedScore}' with '{lastMultipliedScore}'");
 #endif
-                __result = lastRawScore;
+                __result = lastMultipliedScore;
                 return false;
             }
             return true;                
         }
     }
 
-    [HarmonyPatch(typeof(ScoreController), nameof(ScoreController.prevFrameModifiedScore), MethodType.Getter)]
+    [HarmonyPatch(typeof(ScoreController), nameof(ScoreController.modifiedScore), MethodType.Getter)]
     public class ScoreController_prevprevFrameModifiedScore
     {
-        static bool Prefix(ref int ____prevFrameRawScore, ref float ____gameplayModifiersScoreMultiplier, ref int __result)
+        static bool Prefix(ref int ____modifiedScore, ref float ____gameplayModifiersScoreMultiplier, ref int __result)
         {
             int lastModifiedScore = MultiplayerLocalActiveClient_ScoreControllerHandleScoreDidChange.lastModifiedScore;
             if (BailOutController.instance.numFails > 0 && lastModifiedScore >= 0)
             {
-                int modifiedScore = ScoreModel.GetModifiedScoreForGameplayModifiersScoreMultiplier(____prevFrameRawScore, ____gameplayModifiersScoreMultiplier);
+                int modifiedScore = ScoreModel.GetModifiedScoreForGameplayModifiersScoreMultiplier(____modifiedScore, ____gameplayModifiersScoreMultiplier);
 #if DEBUG
                 Logger.log?.Debug($"Multiplayer Bailout detected. Overriding modified score '{modifiedScore}' with '{lastModifiedScore}'");
 #endif

--- a/BailOutMode/Plugin.cs
+++ b/BailOutMode/Plugin.cs
@@ -35,7 +35,7 @@ namespace BailOutMode
             harmony = new Harmony("com.github.zingabopp.bailoutmode");
             PluginMetadata = pluginMetadata;
             Zenjector = zenjector;
-            zenjector.OnGame<BailOutInstaller>(false);
+            zenjector.Install<BailOutInstaller>(Location.GameCore);
             //BS_Utils.Utilities.BSEvents.lateMenuSceneLoadedFresh += MenuLoadedFresh;
         }
 
@@ -76,7 +76,7 @@ namespace BailOutMode
             }
             try
             {
-                harmony.UnpatchAll(harmony.Id);
+                harmony.UnpatchSelf();
             }
             catch (Exception ex)
             {

--- a/BailOutMode/Plugin.cs
+++ b/BailOutMode/Plugin.cs
@@ -43,10 +43,12 @@ namespace BailOutMode
         public void InitWithConfig(Config conf)
         {
             Configuration.instance = conf.Generated<Configuration>();
-            SetGameplaySetupTab(Configuration.instance.EnableGameplayTab);
-            Logger.log.Debug("Config loaded"); 
-            BeatSaberMarkupLanguage.Settings.BSMLSettings.instance.AddSettingsMenu(PluginName, Resource_Settings_Path, Configuration.instance);
-
+            Logger.log.Debug("Config loaded");
+            BeatSaberMarkupLanguage.Util.MainMenuAwaiter.MainMenuInitializing += delegate
+            {
+                SetGameplaySetupTab(Configuration.instance.EnableGameplayTab);
+                BeatSaberMarkupLanguage.Settings.BSMLSettings.Instance.AddSettingsMenu(PluginName, Resource_Settings_Path, Configuration.instance);
+            };
         }
 
         [OnEnable]
@@ -104,13 +106,13 @@ namespace BailOutMode
                 if (enabled)
                 {
                     Logger.log?.Debug($"Enabling GameplaySetup tab.");
-                    GameplaySetup.instance.AddTab(PluginName, Resource_GameplaySettings_Path, Configuration.instance);
+                    GameplaySetup.Instance.AddTab(PluginName, Resource_GameplaySettings_Path, Configuration.instance);
                     gameplayTabEnabled = true;
                 }
                 else
                 {
                     Logger.log?.Debug($"Disabling GameplaySetup tab.");
-                    GameplaySetup.instance.RemoveTab(PluginName);
+                    GameplaySetup.Instance.RemoveTab(PluginName);
                     gameplayTabEnabled = false;
                 }
             }

--- a/BailOutMode/Properties/AssemblyInfo.cs
+++ b/BailOutMode/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.3")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/BailOutMode/manifest.json
+++ b/BailOutMode/manifest.json
@@ -10,7 +10,7 @@
     "BSIPA": "^4.1.3",
     "BS Utils": "^1.6.2",
     "BeatSaberMarkupLanguage": "^1.4.1",
-    "SiraUtil": "^2.1.0"
+    "SiraUtil": "^3.0.0"
   },
   "links": {
     "project-source": "https://github.com/Zingabopp/BailOutMode",

--- a/BailOutMode/manifest.json
+++ b/BailOutMode/manifest.json
@@ -5,7 +5,7 @@
   "id": "bailoutmode",
   "description": "Allows you to continue playing songs without posting a score if you fail, but allows you to post scores if you don't.",
   "version": "1.7.3",
-  "gameVersion": "1.13.4",
+  "gameVersion": "1.19.0",
   "dependsOn": {
     "BSIPA": "^4.1.3",
     "BS Utils": "^1.6.2",

--- a/BailOutMode/manifest.json
+++ b/BailOutMode/manifest.json
@@ -4,8 +4,8 @@
   "author": "Zingabopp",
   "id": "bailoutmode",
   "description": "Allows you to continue playing songs without posting a score if you fail, but allows you to post scores if you don't.",
-  "version": "1.7.3",
-  "gameVersion": "1.19.0",
+  "version": "1.8.0",
+  "gameVersion": "1.40.3",
   "dependsOn": {
     "BSIPA": "^4.1.3",
     "BS Utils": "^1.6.2",


### PR DESCRIPTION
This updates SiraUtil to 3.0.0, which allows it to work on game version 1.19.0. From my testing it works fine.

Also, if you could, please submit the plugin to BeatMods. I think it is really good for practice (I was actually wanting something like this for quite some time, and found BailOutMode just today) and submitting it to BeatMods would allow everyone to install it easily.